### PR TITLE
Select the first country if we are not able to get the local one

### DIFF
--- a/intlphoneinput/src/main/java/net/rimoto/intlphoneinput/IntlPhoneInput.java
+++ b/intlphoneinput/src/main/java/net/rimoto/intlphoneinput/IntlPhoneInput.java
@@ -192,6 +192,10 @@ public class IntlPhoneInput extends RelativeLayout {
             iso = DEFAULT_COUNTRY;
         }
         int defaultIdx = mCountries.indexOfIso(iso);
+        if (defaultIdx == -1) {
+            // In this case we are desperate: selecting the first country available
+            defaultIdx = 0;
+        }
         mSelectedCountry = mCountries.get(defaultIdx);
         mCountrySpinner.setSelection(defaultIdx);
     }


### PR DESCRIPTION
In the very extreme case that we are not able to get the country neither from locale nor from network, just select the first country in the list.

This is one of those things that should never happen...

(internal bug number OMH-37673)